### PR TITLE
Update blocker plugin

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -203,6 +203,12 @@ class SpiderBlocker
             'state' => true,
         ),
         array(
+            'name' => 'MJ12',
+            're' => 'MJ12',
+            'desc' => 'http://www.majestic12.co.uk/projects/dsearch/mj12bot.php',
+            'state' => true,
+        ),
+        array(
             'name' => 'Blekko Bot',
             're' => 'BlekkoBot',
             'desc' => 'http://blekko.com/about/blekkobot',

--- a/src/index.php
+++ b/src/index.php
@@ -3,7 +3,7 @@ namespace Niteoweb\SpiderBlocker;
 /**
  * Plugin Name: Spider Blocker
  * Description: Spider Blocker will block most common bots that consume bandwidth and slow down your server.
- * Version:     1.0.16
+ * Version:     1.0.17
  * Runtime:     5.3+
  * Author:      Easy Blog Networks
  * Author URI:  www.easyblognetworks.com

--- a/src/index.php
+++ b/src/index.php
@@ -483,7 +483,6 @@ class SpiderBlocker
         check_ajax_referer(self::nonce, 'nonce');
         delete_option(self::OptionName);
         $this->generateBlockRules();
-        add_option(self::OptionName, maybe_serialize($this->getBots()), null, 'no');
         add_filter( 'robots_txt', array (&$this, 'robotsFile' ), 10, 2 );
         wp_send_json_success($this->getBots());
     }
@@ -531,22 +530,16 @@ class SpiderBlocker
     function robotsFile( $output, $public ) {
 
         // Get bots list
-        $data = get_option(self::OptionName);
+        $data = $this->getBots();
 
         if ( $data ) {
-            $serialize_data = maybe_unserialize( $data );
-
-            foreach ( $serialize_data as $entry ) {
-              if ( empty( $entry['state'] ) ) {
+            foreach ( $data as $entry ) {
+              if ( ! empty( $entry['state'] ) ) {
                 $output .= "User-agent: " . ucfirst( $entry['re'] ) . "\n";
-                $output .= "Disallow: \n";
+                $output .= "Disallow: /\n";
                 $output .= "\n";
               }
             }
-
-            $output .= 'User-agent: *' . "\n";
-            $output .= "Disallow: /\n";
-            $output .= "\n";
         }
 
         return $output;

--- a/src/index.php
+++ b/src/index.php
@@ -285,6 +285,9 @@ class SpiderBlocker
             add_action('wp_ajax_NSB-set_list', array(&$this, 'saveList'));
             add_action('wp_ajax_NSB-reset_list', array(&$this, 'resetList'));
         }
+
+        // Filter (for robots.txt)
+        add_filter( 'robots_txt', array (&$this, 'robotsFile' ), 10, 2 );
         add_action('generate_rewrite_rules', array(&$this, "generateRewriteRules"));
 
     }
@@ -325,7 +328,7 @@ class SpiderBlocker
     function activatePluginNotice()
     {
         if (get_option(self::OptionName) === false) {
-            update_option(self::OptionName, $this->default_bots);
+            update_option(self::OptionName, maybe_serialize($this->default_bots));
             ?>
             <div class="notice notice-success">
                 <p>SpiderBlocker plugin has enabled blocking of some bots, please review settings by visiting <a
@@ -480,6 +483,8 @@ class SpiderBlocker
         check_ajax_referer(self::nonce, 'nonce');
         delete_option(self::OptionName);
         $this->generateBlockRules();
+        add_option(self::OptionName, maybe_serialize($this->getBots()), null, 'no');
+        add_filter( 'robots_txt', array (&$this, 'robotsFile' ), 10, 2 );
         wp_send_json_success($this->getBots());
     }
 
@@ -501,7 +506,7 @@ class SpiderBlocker
     {
 
         check_ajax_referer(self::nonce, 'nonce');
-        $data = json_decode(stripcslashes($_POST['data']));
+        $data = json_decode(stripcslashes($_POST['data']), true);
 
         if (json_last_error()) {
             if (function_exists('json_last_error_msg')) {
@@ -518,7 +523,33 @@ class SpiderBlocker
         }
 
         $this->generateBlockRules();
+        add_filter( 'robots_txt', array (&$this, 'robotsFile' ), 10, 2 );
         wp_send_json_success($this->getBots());
+
+    }
+
+    function robotsFile( $output, $public ) {
+
+        // Get bots list
+        $data = get_option(self::OptionName);
+
+        if ( $data ) {
+            $serialize_data = maybe_unserialize( $data );
+
+            foreach ( $serialize_data as $entry ) {
+              if ( empty( $entry['state'] ) ) {
+                $output .= "User-agent: " . ucfirst( $entry['re'] ) . "\n";
+                $output .= "Disallow: \n";
+                $output .= "\n";
+              }
+            }
+
+            $output .= 'User-agent: *' . "\n";
+            $output .= "Disallow: /\n";
+            $output .= "\n";
+        }
+
+        return $output;
 
     }
 
@@ -779,12 +810,12 @@ class SpiderBlocker
         <?php
     }
 
-
 }
 
 // Inside WordPress
 if (defined('ABSPATH')) {
     $NiteowebSpiderBlocker_ins = new SpiderBlocker;
+
     add_action( "upgrader_process_complete", array(&$NiteowebSpiderBlocker_ins, 'onPluginUpgrade'), 10, 2);
     register_activation_hook(__FILE__, array(&$NiteowebSpiderBlocker_ins, 'activatePlugin'));
     register_deactivation_hook(__FILE__, array(&$NiteowebSpiderBlocker_ins, 'removeBlockRules'));

--- a/src/index.php
+++ b/src/index.php
@@ -287,7 +287,7 @@ class SpiderBlocker
         }
 
         // Filter (for robots.txt)
-        add_filter( 'robots_txt', array (&$this, 'robotsFile' ), 10, 2 );
+        add_filter( 'robots_txt', array (&$this, 'robotsFile' ), ~PHP_INT_MAX, 2 );
         add_action('generate_rewrite_rules', array(&$this, "generateRewriteRules"));
 
     }
@@ -328,7 +328,7 @@ class SpiderBlocker
     function activatePluginNotice()
     {
         if (get_option(self::OptionName) === false) {
-            update_option(self::OptionName, maybe_serialize($this->default_bots));
+            update_option(self::OptionName, $this->default_bots);
             ?>
             <div class="notice notice-success">
                 <p>SpiderBlocker plugin has enabled blocking of some bots, please review settings by visiting <a
@@ -535,7 +535,7 @@ class SpiderBlocker
         if ( $data ) {
             foreach ( $data as $entry ) {
               if ( ! empty( $entry['state'] ) ) {
-                $output .= "User-agent: " . ucfirst( $entry['re'] ) . "\n";
+                $output .= sprintf( "User-agent: %s\n", $entry['re'] );
                 $output .= "Disallow: /\n";
                 $output .= "\n";
               }

--- a/src/index.php
+++ b/src/index.php
@@ -483,7 +483,7 @@ class SpiderBlocker
         check_ajax_referer(self::nonce, 'nonce');
         delete_option(self::OptionName);
         $this->generateBlockRules();
-        add_filter( 'robots_txt', array (&$this, 'robotsFile' ), 10, 2 );
+        add_filter( 'robots_txt', array (&$this, 'robotsFile' ), ~PHP_INT_MAX, 2 );
         wp_send_json_success($this->getBots());
     }
 
@@ -522,7 +522,7 @@ class SpiderBlocker
         }
 
         $this->generateBlockRules();
-        add_filter( 'robots_txt', array (&$this, 'robotsFile' ), 10, 2 );
+        add_filter( 'robots_txt', array (&$this, 'robotsFile' ), ~PHP_INT_MAX, 2 );
         wp_send_json_success($this->getBots());
 
     }


### PR DESCRIPTION
This PR updates the `spiderblocker` plugin by:
- Adding `MJ12` bot to the list of blocked bots. Other bots `Majestic-12`, `DSearch`, and `MJ12bot` are already present in the list.
- Adding blocked bots to `robots_txt` filter.

### Problem

There seems to be some issue with the way `WordPress` handles the creation of `robots.txt` files which it generates virtually when trying to view the URL let's say - `http://domain.tld/robots.txt`.

Seems weird but `WordPress` does not render the virtual `robots.txt` file if the installation is in a sub-folder and not the root folder. I spent lot of time today trying to dig further into this but so far this is what it looks like. We can work around this with a different approach but that needs to be discussed.