### PR TITLE
Small fix to the plugin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.0.18
+VERSION := 1.0.19
 PLUGINSLUG := spiderblocker
 MAINFILE := index.php
 SRCPATH := $(shell pwd)/src

--- a/src/index.php
+++ b/src/index.php
@@ -5,7 +5,7 @@ namespace Niteoweb\SpiderBlocker;
 /**
  * Plugin Name: Spider Blocker
  * Description: Spider Blocker will block most common bots that consume bandwidth and slow down your server.
- * Version:     1.0.18
+ * Version:     1.0.19
  * Runtime:     5.3+
  * Author:      Easy Blog Networks
  * Text Domain: spiderblocker
@@ -592,16 +592,15 @@ class SpiderBlocker {
 	 * @param bool   $public Blog's public status fetched from the database.
 	 */
 	public function robots_file( $output, $public ) {
-		// Get bots list.
-		$data = $this->get_bots();
+		foreach ( $this->get_bots() as $bot ) {
+			if ( is_array( $bot ) ) {
+				$bot = (object) $bot;
+			}
 
-		if ( $data ) {
-			foreach ( $data as $entry ) {
-				if ( ! empty( $entry['state'] ) ) {
-					$output .= sprintf( "User-agent: %s\n", $entry['re'] );
-					$output .= "Disallow: /\n";
-					$output .= "\n";
-				}
+			if ( ! empty( $bot->state ) ) {
+				$output .= sprintf( "User-agent: %s\n", $bot->re );
+				$output .= "Disallow: /\n";
+				$output .= "\n";
 			}
 		}
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -2,8 +2,8 @@
 Contributors: niteoweb
 Tags: seo, block, bots, htaccess, apache, secure
 Requires at least: 4.0
-Tested up to: 4.9.7
-Stable tag: 1.0.18
+Tested up to: 4.9.8
+Stable tag: 1.0.19
 
 SpiderBlocker will block most common bots that consume bandwidth and slow down your server.
 


### PR DESCRIPTION
Issue - Plugin automatically disabled due to the following error:

`ERROR: #1535122429 Plugin spiderblocker/index.php was automatically deactivated due to an error at Fri, 24 Aug 2018 14:53:49 +0000! 
Error was: Cannot use object of type stdClass as array`

This PR fixes this by adding a check for the `data type`.