### PR TITLE
Fix class constants issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 1.2.5
+VERSION := 1.2.6
 PLUGINSLUG := spiderblocker
 SRCPATH := $(shell pwd)/src
 

--- a/src/index.php
+++ b/src/index.php
@@ -24,42 +24,42 @@ class SpiderBlocker {
 	/**
 	 * @var string
 	 */
-	public const PLUGIN_NAME = 'Spider Blocker';
+	const PLUGIN_NAME = 'Spider Blocker';
 
 	/**
 	 * @var string
 	 */
-	public const PLUGIN_BASE = 'spiderblocker/index.php';
+	const PLUGIN_BASE = 'spiderblocker/index.php';
 
 	/**
 	 * @var string
 	 */
-	public const PLUGIN_VERSION = '@##VERSION##@';
+	const PLUGIN_VERSION = '@##VERSION##@';
 
 	/**
 	 * @var string
 	 */
-	public const MINIMUM_PHP_VERSION = '5.6';
+	const MINIMUM_PHP_VERSION = '5.6';
 
 	/**
 	 * @var string
 	 */
-	public const MINIMUM_WP_VERSION = '4.2.0';
+	const MINIMUM_WP_VERSION = '4.2.0';
 
 	/**
 	 * @var string
 	 */
-	public const OPTIONNAME = 'Niteoweb.SpiderBlocker.Bots';
+	const OPTIONNAME = 'Niteoweb.SpiderBlocker.Bots';
 
 	/**
 	 * @var string
 	 */
-	public const NONCE = 'Niteoweb.SpiderBlocker.Nonce';
+	const NONCE = 'Niteoweb.SpiderBlocker.Nonce';
 
 	/**
 	 * @var string
 	 */
-	public const CHECKHOOK = 'Niteoweb.SpiderBlocker.CheckHook';
+	const CHECKHOOK = 'Niteoweb.SpiderBlocker.CheckHook';
 
 	/**
 	 * @var array

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,7 +3,7 @@ Contributors: niteoweb
 Tags: seo, block, bots, htaccess, apache, secure
 Requires at least: 4.0
 Tested up to: 5.4.2
-Stable tag: 1.2.5
+Stable tag: 1.2.6
 
 SpiderBlocker will block most common bots that consume bandwidth and slow down your server.
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -32,6 +32,9 @@ with Apache server and mod_rewrite enabled.
 
 
 == Changelog ==
+= v1.2.6 =
+- Fix issue with class constants
+
 = v1.2.5 =
 - Visual fixes and code clean-up
 - Added support for LiteSpeed server


### PR DESCRIPTION
This PR removes the visibility of class constants as they were introduced in PHP 7.0 and we have the minimum requirement set to 5.6.